### PR TITLE
fix: prevent duplicate activities in select dropdown

### DIFF
--- a/src/static/app.js
+++ b/src/static/app.js
@@ -13,6 +13,9 @@ document.addEventListener("DOMContentLoaded", () => {
       // Clear loading message
       activitiesList.innerHTML = "";
 
+      // Clear the select dropdown to prevent duplicates
+      activitySelect.innerHTML = '';
+
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
         const activityCard = document.createElement("div");


### PR DESCRIPTION
This pull request fixes an issue where the same activities appeared multiple times in the select activity dropdown. The dropdown is now cleared before repopulating, ensuring each activity appears only once.